### PR TITLE
two bugs fixed one feature addition

### DIFF
--- a/Csound/Csound.tmLanguage
+++ b/Csound/Csound.tmLanguage
@@ -102,6 +102,14 @@
 			<key>name</key>
 			<string>variable.parameter.csd</string>
 		</dict>
+		<dict>
+			<key>comment</key>
+			<string>operators</string>
+			<key>match</key>
+			<string>(\+|\-|\*|\/|\%|\=)</string>
+			<key>name</key>
+			<string>entity.name.tag.csd</string>
+		</dict>
 	</array>
 	<key>scopeName</key>
 	<string>source.csd</string>

--- a/Csound/Csound.tmLanguage
+++ b/Csound/Csound.tmLanguage
@@ -38,7 +38,7 @@
 			<key>comment</key>
 			<string>header opcodes</string>
 			<key>match</key>
-			<string>(sr|kr|ksmps|nchnls|0dbfs)\b</string>
+			<string>\b(sr|kr|ksmps|nchnls|0dbfs)\b</string>
 			<key>name</key>
 			<string>constant.language.csd</string>
 		</dict>
@@ -82,7 +82,7 @@
 			<key>comment</key>
 			<string>instr &amp; UDO</string>
 			<key>match</key>
-			<string>(instr|endin|opcode|endop)</string>
+			<string>\b(instr|endin|opcode|endop)\b</string>
 			<key>name</key>
 			<string>entity.name.tag.csd</string>
 		</dict>


### PR DESCRIPTION
fixed more missing word boundaries, this time for (sr|kr|ksmps|nchnls|0dbfs) and for (instr|endin|opcode|endop).  these created the same incorrect matches within a larger string as before with pfields.

added first pass at matching arithmetic operators, matched to entity.name.tag.csd for now.  looks good with my color theme.
