### PR TITLE
Update Csound Manual link.

### DIFF
--- a/Csound/search_in_manual.py
+++ b/Csound/search_in_manual.py
@@ -5,7 +5,7 @@ class SearchInManualCommand(sublime_plugin.TextCommand):
 
     def run(self, edit):
         word = self.view.substr(self.view.word((self.view.sel()[0].b)))
-        webbrowser.open_new_tab("http://www.csounds.com/manual/html/%s" % word)
+        webbrowser.open_new_tab("http://www.csounds.com/manual/html/%s.html" % word)
 
     def is_visible(self):
         return self.view.file_name() and self.view.file_name()[-4:] == ".csd"


### PR DESCRIPTION
Visiting the url without the trailing `.html` filepath was leading to a 404 page.
